### PR TITLE
Make tests not required

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -28,16 +28,20 @@ i18n.merge_file(
     install_dir: join_paths(get_option('datadir'), 'metainfo')
 )
 
-test (
-    'Validate desktop file',
-    find_program('desktop-file-validate'),
-    args: join_paths(meson.current_build_dir (), meson.project_name() + '.desktop')
-)
-
-test (
-    'Validate appdata file',
-    find_program('appstreamcli'),
-    args: ['validate', join_paths(meson.current_build_dir (), meson.project_name() + '.appdata.xml')]
-)
-
+desktop_file_validate = find_program('desktop-file-validate', required:false)
+if desktop_file_validate.found()
+    test (
+        'Validate desktop file',
+        desktop_file_validate,
+        args: join_paths(meson.current_build_dir (), meson.project_name() + '.desktop')
+    )
+endif
+appstreamcli = find_program(['appstreamcli', 'appstream-util'], required:false)
+if appstreamcli.found()
+    test (
+        'Validate appdata file',
+        appstreamcli,
+        args: ['validate', join_paths(meson.current_build_dir (), meson.project_name() + '.appdata.xml')]
+    )
+endif
 


### PR DESCRIPTION
The desktop-file-validate and appstream-cli are not required to build the application.

This PR makes both appstream-cli and desktop-file-validate not required. And also adds `appstream-util` as a binary name for `appstreamcli`

This will allow me to build a flatpak package for dippi. 

Thanks!

PS: the post install step is missing, the cache icons of hicolor theme must be refreshed otherwise the icons won't show up correctly