### PR TITLE
add prefix to install_data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 *~
 build/
 src/display-calc
-
+builddir/

--- a/data/meson.build
+++ b/data/meson.build
@@ -3,11 +3,11 @@ icon_sizes = ['48', '64', '128']
 foreach i : icon_sizes
     install_data(
         join_paths('icons', i, meson.project_name() + '.svg'),
-        install_dir: join_paths(get_option('datadir'), 'icons', 'hicolor', i + 'x' + i, 'apps')
+        install_dir: join_paths(get_option('prefix'), get_option('datadir'), 'icons', 'hicolor', i + 'x' + i, 'apps')
     )
     install_data(
         join_paths('icons', i, meson.project_name() + '.svg'),
-        install_dir: join_paths(get_option('datadir'), 'icons', 'hicolor', i + 'x' + i + '@2', 'apps')
+        install_dir: join_paths(get_option('prefix'), get_option('datadir'), 'icons', 'hicolor', i + 'x' + i + '@2', 'apps')
     )
 endforeach
 
@@ -17,7 +17,7 @@ i18n.merge_file(
     po_dir: join_paths(meson.source_root(), 'po'),
     type: 'desktop',
     install: true,
-    install_dir: join_paths(get_option('datadir'), 'applications')
+    install_dir: join_paths(get_option('prefix'), get_option('datadir'), 'applications')
 )
 
 i18n.merge_file(
@@ -25,7 +25,7 @@ i18n.merge_file(
     output: meson.project_name() + '.appdata.xml',
     po_dir: join_paths(meson.source_root(), 'po'),
     install: true,
-    install_dir: join_paths(get_option('datadir'), 'metainfo')
+    install_dir: join_paths(get_option('prefix'), get_option('datadir'), 'metainfo')
 )
 
 desktop_file_validate = find_program('desktop-file-validate', required:false)


### PR DESCRIPTION
When I tried to create a flatpak for the application, I got into this error. Somehow, the prefix is not correctly set with flatpak/meson. Works correctly without it in my main system; but still works after the patch :+1: 

```
Renaming com.github.cassidyjames.dippi.appdata.xml to share/appdata/com.github.cassidyjames.dippi.appdata.xml
Committing stage cleanup to cache
Finishing app
Not exporting share/applications/granite-demo.desktop, wrong prefix
Exporting share/applications/com.github.cassidyjames.dippi.desktop
Not exporting share/icons/hicolor/22x22/actions/open-menu.svg, wrong prefix
Not exporting share/icons/hicolor/32x32/actions/open-menu.svg, wrong prefix
Not exporting share/icons/hicolor/24x24/actions/open-menu.svg, wrong prefix
Not exporting share/icons/hicolor/24x24/actions/appointment.svg, wrong prefix
Exporting share/icons/hicolor/48x48@2/apps/com.github.cassidyjames.dippi.svg
Not exporting share/icons/hicolor/48x48/actions/open-menu.svg, wrong prefix
Exporting share/icons/hicolor/48x48/apps/com.github.cassidyjames.dippi.svg
Exporting share/icons/hicolor/64x64@2/apps/com.github.cassidyjames.dippi.svg
Exporting share/icons/hicolor/128x128@2/apps/com.github.cassidyjames.dippi.svg
Not exporting share/icons/hicolor/scalable/actions/open-menu-symbolic.svg, wrong prefix
Not exporting share/icons/hicolor/16x16/actions/open-menu.svg, wrong prefix
Not exporting share/icons/hicolor/16x16/actions/appointment.svg, wrong prefix
Exporting share/icons/hicolor/128x128/apps/com.github.cassidyjames.dippi.svg
Exporting share/icons/hicolor/64x64/apps/com.github.cassidyjames.dippi.svg
Please review the exported files and the metadata

```

Instead of this
```
Installing com.github.cassidyjames.dippi to /app/bin/com.github.cassidyjames.dippi
Installing data/com.github.cassidyjames.dippi.desktop to /app/share/applications/com.github.cassidyjames.dippi.desktop
Installing data/com.github.cassidyjames.dippi.appdata.xml to /app/share/metainfo/com.github.cassidyjames.dippi.appdata.xml
Installing /run/build/dippi/data/icons/48/com.github.cassidyjames.dippi.svg to /app/share/icons/hicolor/48x48/apps
Installing /run/build/dippi/data/icons/48/com.github.cassidyjames.dippi.svg to /app/share/icons/hicolor/48x48@2/apps
Installing /run/build/dippi/data/icons/64/com.github.cassidyjames.dippi.svg to /app/share/icons/hicolor/64x64/apps
Installing /run/build/dippi/data/icons/64/com.github.cassidyjames.dippi.svg to /app/share/icons/hicolor/64x64@2/apps
Installing /run/build/dippi/data/icons/128/com.github.cassidyjames.dippi.svg to /app/share/icons/hicolor/128x128/apps
Installing /run/build/dippi/data/icons/128/com.github.cassidyjames.dippi.svg to /app/share/icons/hicolor/128x128@2/apps

```