### PR TITLE
flatpak: Add --device=dri

### DIFF
--- a/com.github.cassidyjames.dippi.json
+++ b/com.github.cassidyjames.dippi.json
@@ -7,7 +7,8 @@
     "finish-args": [
         "--share=ipc",
         "--socket=fallback-x11",
-        "--socket=wayland"
+        "--socket=wayland",
+        "--device=dri"
     ],
     "modules": [
         {


### PR DESCRIPTION
GTK4 is hardware accelerated, no need to prevent that.