### PR TITLE
Fix crash when width/height is set to 0

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -347,7 +347,9 @@ public class Dippi.MainWindow : Adw.ApplicationWindow {
             string? text = width_entry.get_text ();
             if (text != null && text != "") {
                 width = int.parse (text);
-
+                if ( width == 0 ) {
+                    return;
+                }
                 is_default_width = false;
 
                 recalculate_aspect (width, height);
@@ -372,7 +374,9 @@ public class Dippi.MainWindow : Adw.ApplicationWindow {
             string? text = height_entry.get_text ();
             if (text != null && text != "") {
                 height = int.parse (height_entry.get_text ());
-
+                if ( height == 0 ) {
+                    return;
+                }
                 is_default_height = false;
 
                 recalculate_aspect (width, height);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -345,13 +345,9 @@ public class Dippi.MainWindow : Adw.ApplicationWindow {
 
         width_entry.changed.connect (() => {
             string? text = width_entry.get_text ();
-            if (text != null && text != "") {
-                width = int.parse (text);
-                if ( width == 0 ) {
-                    return;
-                }
+            width = int.parse (text);
+            if (width != 0) {
                 is_default_width = false;
-
                 recalculate_aspect (width, height);
                 assess_dpi (
                     recalculate_dpi (inches, width, height),
@@ -372,13 +368,9 @@ public class Dippi.MainWindow : Adw.ApplicationWindow {
 
         height_entry.changed.connect (() => {
             string? text = height_entry.get_text ();
-            if (text != null && text != "") {
-                height = int.parse (height_entry.get_text ());
-                if ( height == 0 ) {
-                    return;
-                }
+            height = int.parse (height_entry.get_text ());
+            if (height != 0) {
                 is_default_height = false;
-
                 recalculate_aspect (width, height);
                 assess_dpi (
                     recalculate_dpi (inches, width, height),


### PR DESCRIPTION
Fixes a bug in dippi where it crashes when the user sets height or width to 0.

Resolves #111 