### PR TITLE
Fix deprecated top-level developer_name in AppData XML

### DIFF
--- a/data/metainfo.appdata.xml.in
+++ b/data/metainfo.appdata.xml.in
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2018–2023 Cassidy James Blaede <c@ssidyjam.es> -->
+<!-- Copyright 2018–2024 Cassidy James Blaede <c@ssidyjam.es> -->
 <component type="desktop">
   <id>com.github.cassidyjames.dippi</id>
   <metadata_license>CC0</metadata_license>
@@ -344,8 +344,9 @@
     </screenshot>
   </screenshots>
   <content_rating type="oars-1.1"></content_rating>
-  <developer id="com.github.cassidyjames">
-    <name>Cassidy James Blaede</name>
+  <developer_name translatable="no">Cassidy James Blaede</developer_name>
+  <developer id="com.cassidyjames">
+    <name translatable="no">Cassidy James Blaede</name>
   </developer>
   <url type="homepage">https://cassidyjames.com/dippi</url>
   <url type="bugtracker">https://github.com/cassidyjames/dippi/issues</url>

--- a/data/metainfo.appdata.xml.in
+++ b/data/metainfo.appdata.xml.in
@@ -344,7 +344,7 @@
     </screenshot>
   </screenshots>
   <content_rating type="oars-1.1"></content_rating>
-  <developer>
+  <developer id="com.github.cassidyjames">
     <name>Cassidy James Blaede</name>
   </developer>
   <url type="homepage">https://cassidyjames.com/dippi</url>

--- a/data/metainfo.appdata.xml.in
+++ b/data/metainfo.appdata.xml.in
@@ -344,7 +344,9 @@
     </screenshot>
   </screenshots>
   <content_rating type="oars-1.1"></content_rating>
-  <developer_name>Cassidy James Blaede</developer_name>
+  <developer>
+    <name>Cassidy James Blaede</name>
+  </developer>
   <url type="homepage">https://cassidyjames.com/dippi</url>
   <url type="bugtracker">https://github.com/cassidyjames/dippi/issues</url>
   <url type="translate">https://github.com/cassidyjames/dippi/tree/main/po#readme</url>


### PR DESCRIPTION
Use the `name` element in a `developer` block instead, as recommended by `appstreamcli` 1.0.0.

This fixes all warnings when validating the AppData XML file, although there are still informational messages:

```
I: com.github.cassidyjames.dippi:532: developer-id-missing
   The `developer` element is missing an `id` property, containing a unique string ID for the
   developer. Consider adding a unique ID.

✔ Validation was successful: infos: 1, pedantic: 8
```