### PR TITLE
GNOME 49

### DIFF
--- a/com.github.cassidyjames.dippi.json
+++ b/com.github.cassidyjames.dippi.json
@@ -1,15 +1,14 @@
 {
   "app-id": "com.github.cassidyjames.dippi",
   "runtime" : "org.gnome.Platform",
-  "runtime-version": "46",
+  "runtime-version": "49",
   "sdk": "org.gnome.Sdk",
   "command": "com.github.cassidyjames.dippi",
   "finish-args": [
     "--share=ipc",
     "--socket=fallback-x11",
     "--socket=wayland",
-    "--device=dri",
-    "--share=ipc"
+    "--device=dri"
   ],
   "modules": [
     {

--- a/data/gresource.xml
+++ b/data/gresource.xml
@@ -3,7 +3,6 @@
   <gresource prefix="/com/github/cassidyjames/dippi/">
     <file alias="metainfo.xml" preprocess="xml-stripblanks">metainfo.appdata.xml.in</file>
     <file alias="style.css">styles/style.css</file>
-    <file alias="style-dark.css">styles/dark.css</file>
   </gresource>
   <gresource prefix="/com/github/cassidyjames/dippi/icons/scalable/actions/">
     <file alias="com.github.cassidyjames.dippi.svg" preprocess="xml-stripblanks">icons/com.github.cassidyjames.dippi.svg</file>

--- a/data/metainfo.appdata.xml.in
+++ b/data/metainfo.appdata.xml.in
@@ -83,11 +83,14 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release version="4.1.1" date="2024-08-21">
+    <release version="4.1.1" date="2025-11-01">
       <description>
-        <p>Lies! Deception!</p>
+        <p> GNOME 49 “Brescia”</p>
         <ul>
           <li>Better handle several common resolutions/aspect ratios</li>
+          <li>Respect desktop accent color instead of always using purple</li>
+          <li>Updated with the latest GNOME 49 platform and Adwaita 1.8</li>
+          <li>Updated Italian translations thanks to Albano Battistella</li>
         </ul>
       </description>
       <issues>

--- a/data/styles/dark.css
+++ b/data/styles/dark.css
@@ -1,2 +1,0 @@
-@define-color accent_color @purple_1;
-@define-color accent_bg_color @purple_4;

--- a/data/styles/style.css
+++ b/data/styles/style.css
@@ -1,6 +1,3 @@
-@define-color accent_color @purple_5;
-@define-color accent_bg_color @purple_3;
-
 .title-1 {
   font-size: 225%;
 }

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project(
   'com.github.cassidyjames.dippi',
   'vala', 'c',
   version: '4.1.1',
-  meson_version: '>=1.3.2',
+  meson_version: '>=1.5.2',
 )
 
 gnome = import('gnome')
@@ -35,8 +35,8 @@ executable(
   asresources,
   config_file,
   dependencies: [
-    dependency('gtk4', version: '>=4.14.4'),
-    dependency('libadwaita-1', version: '>=1.5.2'),
+    dependency('gtk4', version: '>=4.19.4'),
+    dependency('libadwaita-1', version: '>=1.8.1'),
     meson.get_compiler('c').find_library('m', required : false)
   ],
   install: true


### PR DESCRIPTION
- Respect accent colors
- Bump to GNOME 49